### PR TITLE
fix: remove file_path from lut_entries UNIQUE constraint to prevent multi-path dedup failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21...3.31)
 project(ZlibValidation
     LANGUAGES CXX
-    VERSION 1.2.1
+    VERSION 1.2.2
 )
 
 # Define author information

--- a/include/LibDatabase.hpp
+++ b/include/LibDatabase.hpp
@@ -59,9 +59,13 @@ public:
    * @brief Insert one LUT record into lut_entries.
    *
    * Uses INSERT OR IGNORE so repeated calls with the same UNIQUE key
-   * (file_path, pvt_corner, aged_year, arc_type, related_pin) are no-ops.
+   * (pvt_corner, aged_year, cell_name, output_pin, related_pin, "when", arc_type)
+   * are no-ops. `file_path` is deliberately excluded from the UNIQUE constraint
+   * because the same .lib data may exist under multiple paths (symlinks, directory
+   * mirrors); it is stored as a provenance column but does not participate in
+   * semantic deduplication.
    *
-   * @param file_path     Source .lib file path (for provenance).
+   * @param file_path     Source .lib file path (for provenance only — not in UNIQUE).
    * @param library_name  Library name (basename of .lib file).
    * @param pvt_corner    PVT corner string (e.g. "SS_1p08V_125C").
    * @param aged_year     Aging year (e.g. 0.01 for fresh, 10000 for aged).

--- a/include/version.h
+++ b/include/version.h
@@ -5,8 +5,8 @@
 #define APP_NAME          "ZlibValidation"
 #define APP_VERSION_MAJOR 1
 #define APP_VERSION_MINOR 2
-#define APP_VERSION_PATCH 1
-#define APP_VERSION       "1.2.1"
+#define APP_VERSION_PATCH 2
+#define APP_VERSION       "1.2.2"
 #define APP_AUTHOR        "Song Zixuan (宋子轩)"
 #define APP_CONTACT       "zx.song@zju.edu.cn, songcedar@outlook.com"
-#define BUILD_TIMESTAMP   "2026-06-23 12:06:48"
+#define BUILD_TIMESTAMP   "2026-07-02 20:53:29"

--- a/src/LibDatabase.cpp
+++ b/src/LibDatabase.cpp
@@ -18,6 +18,9 @@ static std::vector<float> toFloatBlob(const std::vector<double> &src) {
 
 // =========================================================================
 // DDL — only the lut_entries table (the rest is managed by Python)
+// NOTE: file_path is deliberately excluded from the UNIQUE constraint.
+// The same .lib data may exist under multiple paths (symlinks, directory mirrors),
+// so UNIQUE uses semantic keys only. file_path remains as a provenance column.
 // =========================================================================
 
 static const char *DDL_LUT_ENTRIES = R"sql(
@@ -44,7 +47,7 @@ static const char *DDL_LUT_ENTRIES = R"sql(
     temperature   REAL,
     voltage       REAL,
     ingested_at   TEXT NOT NULL DEFAULT (datetime('now')),
-    UNIQUE(file_path, pvt_corner, aged_year, cell_name, output_pin,
+    UNIQUE(pvt_corner, aged_year, cell_name, output_pin,
            related_pin, "when", arc_type)
   );
 )sql";

--- a/test/test_libdb.cpp
+++ b/test/test_libdb.cpp
@@ -180,7 +180,7 @@ TEST_F(LibDatabaseTest, MultipleArcTypesWritten) {
   EXPECT_EQ(count, 4);
 }
 
-// Same UNIQUE key (file/pvt/year/cell/pin/related_pin/arc_type) but different
+// Same UNIQUE key (pvt/year/cell/pin/related_pin/arc_type) but different
 // `when` conditions must both persist — the core regression for the silent-dedup
 // data-loss bug. Before `when` joined the UNIQUE constraint, the second insert
 // was silently dropped by INSERT OR IGNORE.
@@ -210,4 +210,35 @@ TEST_F(LibDatabaseTest, DifferentWhenSameKeyBothPersisted) {
     distinct_when++;
   }
   EXPECT_EQ(distinct_when, 2);
+}
+
+// Same data inserted with different file_paths must deduplicate to one row.
+// Before the fix, file_path was part of the UNIQUE constraint, so 3 different
+// paths → 3 rows. After the fix, file_path is excluded from the constraint,
+// so only the first insert survives (INSERT OR IGNORE).
+TEST_F(LibDatabaseTest, DifferentPathsDeduplicated) {
+  std::vector<double> idx = {0.01, 0.0368, 0.1309};
+  std::vector<double> idx2 = {0.00077, 0.0017, 0.00355};
+  std::vector<double> vals = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
+
+  // Three inserts — identical semantic data, different file paths
+  db_->writeLutEntry("data/raw/A.lib", "lib", "SS_1p08V_125C", 0.01,
+                     "CELL", "Y", "A", "negative_unate", "combinational", "!B",
+                     "cell_rise", 3, 3, idx, idx2, vals, 1, 25.0, 1.0);
+  db_->writeLutEntry("mirror/B.lib", "lib", "SS_1p08V_125C", 0.01,
+                     "CELL", "Y", "A", "negative_unate", "combinational", "!B",
+                     "cell_rise", 3, 3, idx, idx2, vals, 1, 25.0, 1.0);
+  db_->writeLutEntry("backup/C.lib", "lib", "SS_1p08V_125C", 0.01,
+                     "CELL", "Y", "A", "negative_unate", "combinational", "!B",
+                     "cell_rise", 3, 3, idx, idx2, vals, 1, 25.0, 1.0);
+
+  SQLite::Database check(db_path_, SQLite::OPEN_READWRITE);
+  SQLite::Statement cnt(check, "SELECT count(*) FROM lut_entries");
+  ASSERT_TRUE(cnt.executeStep());
+  EXPECT_EQ(cnt.getColumn(0).getInt(), 1);
+
+  // The surviving row should hold the first-inserted file_path
+  SQLite::Statement q(check, "SELECT file_path FROM lut_entries");
+  ASSERT_TRUE(q.executeStep());
+  EXPECT_STREQ(q.getColumn(0).getText(), "data/raw/A.lib");
 }

--- a/test/test_libfile_db.cpp
+++ b/test/test_libfile_db.cpp
@@ -127,11 +127,14 @@ TEST_F(LibFileWriteToDBTest, IdempotentWrite) {
   libfile.writeToDB(db_path_, "SS_1p08V_125C", 0.01);
   libfile.writeToDB(db_path_, "SS_1p08V_125C", 0.01);
 
-  // Verify no duplicate UNIQUE combinations
+  // Verify no duplicate UNIQUE combinations.
+  // Note: file_path is deliberately excluded — it is provenance only, not part
+  // of the UNIQUE constraint. The DISTINCT keys match the actual constraint:
+  // (pvt_corner, aged_year, cell_name, output_pin, related_pin, "when", arc_type)
   SQLite::Database db(db_path_, SQLite::OPEN_READWRITE);
   SQLite::Statement distinct(db,
       "SELECT count(*) FROM ("
-      "  SELECT DISTINCT file_path, pvt_corner, aged_year, "
+      "  SELECT DISTINCT pvt_corner, aged_year, "
       "  cell_name, output_pin, related_pin, \"when\", arc_type "
       "  FROM lut_entries)");
   ASSERT_TRUE(distinct.executeStep());


### PR DESCRIPTION
The UNIQUE constraint incorrectly included `file_path`, causing the same .lib
data from different directory mirrors (aging-ml/DATA/raw/, 0516_scripts/LIBRARY/,
Aging/ML/DATA/raw/) to be inserted as 2~3 duplicate rows.

- file_path is now a provenance-only column; it does not participate in UNIQUE.
- New UNIQUE key: (pvt_corner, aged_year, cell_name, output_pin, related_pin,
  "when", arc_type)
- Added DifferentPathsDeduplicated regression test (3 paths → 1 row)
- Updated IdempotentWrite DISTINCT query to match new constraint semantics
- Updated DDL comments and header docs for clarity
- Version bump 1.2.1 → 1.2.2

Co-Authored-By: Claude <noreply@anthropic.com>
